### PR TITLE
Add missing backend requirements

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,1 +1,8 @@
-websockets
+certifi==2024.7.4
+charset-normalizer==3.3.2
+idna==3.7
+requests==2.32.3
+urllib3==2.2.2
+websockets==12.0
+loguru==0.7.2
+streamcontroller-plugin-tools>=2.0.1


### PR DESCRIPTION
`streamcontroller-plugin-tools` and `loguru` are always needed I got an error that `requests` is missing which requires the other added modules